### PR TITLE
Added more fields to getScanResult

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -326,7 +326,7 @@ public class WifiWizard extends CordovaPlugin {
 		for (ScanResult scan : scanResults) {
 			JSONObject lvl = new JSONObject();
 			try {
-				lvl.put("level", wifiManager.calculateSignalLevel(scan.level, 6));
+				lvl.put("level", wifiManager.calculateSignalLevel(scan.level, 5));
 				lvl.put("SSID", scan.SSID);
 				returnList.put(lvl);
 			} catch (JSONException e) {


### PR DESCRIPTION
getScanResult now returns more informations about network. More info can be added.

With this patch, we can get more informations about the scanned wifis.
This will break any application that is using getScannedResult return value as a simple array of strings.

I do not want to create a specific function for this. What do you think about this?

Ps: the resulting level is an integer between 0 an 4 where 0 is no signal and 4 is the max.
When we decided, a little fix to the README will be required.

Daniele.
