### PR TITLE
Clobber WifiWizard.js automatically via Cordova plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Run `phonegap plugin install https://github.com/parsonsmatt/WifiWizard.git`
 
 ### Changelog:
 
+* v0.2.6 - Clobber WifiWizard.js automatically via Cordova plugin architecture
 * v0.2.6 - Added `isWifiEnabled`, `setWifiEnabled`
 * v0.2.5 - Fixes `getConnectedSSID` error handlers
 * v0.2.4 - Added `getConnectedSSID` method

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Version 0.2.6
 
-This Phonegap plugin enables WiFi management from within Phonegap applications. 
+This Phonegap plugin enables WiFi management from within Phonegap applications.
 
 Only Android is in development at this time. iOS is planned to be developed, with other platforms following.
 
 ### Installation
 
-Run `phonegap plugin install https://github.com/parsonsmatt/WifiWizard.git` and add `<script src="WifiWizard.js"></script>` in your Phonegap project.
+Run `phonegap plugin install https://github.com/parsonsmatt/WifiWizard.git`
 
 ### Usage from within Cordova/Phonegap:
 
-* `WifiWizard.formatWifiConfig(SSID, password, algorithm);` formats the wifi configuration information into a JSON for use with the addNetwork function. Currently, only WPA is supported for the `algorithm` value. 
+* `WifiWizard.formatWifiConfig(SSID, password, algorithm);` formats the wifi configuration information into a JSON for use with the addNetwork function. Currently, only WPA is supported for the `algorithm` value.
 * `WifiWizard.formatWPAConfig(SSID, password);` is a helper method. It returns an object which can be used to add a WPA wifi network.
 * `WifiWizard.addNetwork(wifi, win, fail);` adds the network to the list of available networks that the user can log into. `wifi` needs to be an object as formatted by formatWifiConfig. `win` and `fail` are callback functions to be executed based on the result of the call.
 * `WifiWizard.removeNetwork(SSID, win, fail);` removes the network with the given SSID. As above, `win` and `fail` are callback functions.
-* `WifiWizard.connectNetwork(SSID, win, fail);` connects the phone to the given Wifi network. 
-* `WifiWizard.disconnectNetwork(SSID, win, fail);` disconnects the phone to the given Wifi network. 
+* `WifiWizard.connectNetwork(SSID, win, fail);` connects the phone to the given Wifi network.
+* `WifiWizard.disconnectNetwork(SSID, win, fail);` disconnects the phone to the given Wifi network.
 * `WifiWizard.listNetworks(listHandler, fail);` retrieves a list of the configured networks as an array of strings and passes them to the function listHandler.
 * `WifiWizard.startScan(listHandler, fail);` start WiFi scanning.
 * `WifiWizard.getScanResults(listHandler, fail);` retrieves a list of the available networks as an array of strings and passes them to the function listHandler.
@@ -37,5 +37,5 @@ Run `phonegap plugin install https://github.com/parsonsmatt/WifiWizard.git` and 
 * v0.1.1 - `addNetwork` will now update the network if the SSID already exists.
 * v0.1.0 - All functions now work!
 * v0.0.3 - Fixed errors in native implementation. Currently, Add and Remove networks aren't working, but others are working as expected.
-* v0.0.2 - Changed plugin.xml and WifiWizard.js to attach WifiWizard directly to the HTML. 
+* v0.0.2 - Changed plugin.xml and WifiWizard.js to attach WifiWizard directly to the HTML.
 * v0.0.1 - Initial commit

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Run `phonegap plugin install https://github.com/parsonsmatt/WifiWizard.git`
 
 ### Changelog:
 
-* v0.2.6 - Clobber WifiWizard.js automatically via Cordova plugin architecture
+* v0.2.7 - Clobber WifiWizard.js automatically via Cordova plugin architecture
 * v0.2.6 - Added `isWifiEnabled`, `setWifiEnabled`
 * v0.2.5 - Fixes `getConnectedSSID` error handlers
 * v0.2.4 - Added `getConnectedSSID` method

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	id="com.pylonproducts.wifiwizard"
-	version="0.2.6">
+	version="0.2.7">
 
     <name>WifiWizard</name>
     <description>This plugin allows Phonegap applications to manage Wifi connections.</description>
@@ -12,29 +12,25 @@
     <license>Apache 2.0</license>
 	<repo>https://github.com/parsonsmatt/WifiWizard/</repo>
 
-	<asset src="www/WifiWizard.js" target="WifiWizard.js" />
-	
-    <js-module src="www/WifiWizard.js" name="WifiWizard">
-        <runs />
+	<js-module src="www/WifiWizard.js" name="DynamicUpdate">
+        <clobbers target="WifiWizard" />
     </js-module>
 
     <platform name="android">
-		
+
 		<config-file target="AndroidManifest.xml" parent="/manifest">
 			<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 			<uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
 		</config-file>
-		
-		<config-file target="res/xml/config.xml" parent="/*">	
+
+		<config-file target="res/xml/config.xml" parent="/*">
 			<feature name="WifiWizard">
 				<param name="android-package" value="com.pylonproducts.wifiwizard.WifiWizard" />
 				<param name="onload" value="true" />
 			</feature>
 		</config-file>
-		
-	<source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java" target-dir="src/com/pylonproducts/wifiwizard" />	
+
+	<source-file src="src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java" target-dir="src/com/pylonproducts/wifiwizard" />
     </platform>
-    
+
 </plugin>
-
-

--- a/www/WifiWizard.js
+++ b/www/WifiWizard.js
@@ -259,4 +259,4 @@ var WifiWizard = {
 	}
 };
 
-// module.exports = WifiWizard;
+module.exports = WifiWizard;


### PR DESCRIPTION
This is the standard way to include Cordova plugin JavaScript, so that you don't need to hardcode a `script` reference.