### PR TITLE
getScanResults objects return RSSI vs "numBars"

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -371,7 +371,7 @@ public class WifiWizard extends CordovaPlugin {
         for (ScanResult scan : scanResults) {
             JSONObject lvl = new JSONObject();
             try {
-                lvl.put("level", wifiManager.calculateSignalLevel(scan.level, 5));
+                lvl.put("level", scan.level);
                 lvl.put("SSID", scan.SSID);
                 lvl.put("BSSID", scan.BSSID);
                 returnList.put(lvl);


### PR DESCRIPTION
getScanResults' `scanResult.level` attributes were returning a pre-calculated result vs. raw RSSI. Changed to match semantics of the native Android WifiManager API call.

If plugin users need to use `WifiManager.calculateSignalLevel`, e.g. to precalculate number of bars, I can add a commit that:

 - Exposes `WifiManager.calculateSignalLevel` as a separate function called by a `cordova.exec()`; and / or
 - Allows plugin users to pass an options object to getScanResults, e.g. `WifiWizard.getScanResults({numLevels: 5})`.

Would not need these additional functions myself, but I'm happy to add them in for the sake of completeness if you'd like to continue in this direction.