### PR TITLE
add options hash to modify getScanResults level

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -89,7 +89,7 @@ public class WifiWizard extends CordovaPlugin {
             return this.startScan(callbackContext);
         }
         else if(action.equals(GET_SCAN_RESULTS)) {
-            return this.getScanResults(callbackContext);
+            return this.getScanResults(callbackContext, data);
         }
         else if(action.equals(DISCONNECT)) {
             return this.disconnect(callbackContext);
@@ -361,17 +361,58 @@ public class WifiWizard extends CordovaPlugin {
        *    of the scanned networks.
        *
        *    @param    callbackContext        A Cordova callback context
+       *    @param    data                   JSONArray with [0] == JSONObject
        *    @return    true
        */
-    private boolean getScanResults(CallbackContext callbackContext) {
+    private boolean getScanResults(CallbackContext callbackContext, JSONArray data) {
         List<ScanResult> scanResults = wifiManager.getScanResults();
 
         JSONArray returnList = new JSONArray();
 
+        Integer numLevels = null;
+
+        if (!data.isNull(0)) {
+            try {
+                JSONObject options = data.getJSONObject(0);
+
+                if (options.has("numLevels")) {
+                    Integer levels = options.optInt("numLevels");
+
+                    if (levels > 0) {
+                        numLevels = levels;
+                    } else if (options.optBoolean("numLevels", false)) {
+                        // use previous default for {numLevels: true}
+                        numLevels = 5;
+                    }
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+
         for (ScanResult scan : scanResults) {
+            /*
+             * @todo - breaking change, remove this notice when tidying new release and explain changes, e.g.:
+             *   0.y.z includes a breaking change to WifiWizard.getScanResults().
+             *   Earlier versions set scans' level attributes to a number derived from wifiManager.calculateSignalLevel.
+             *   This update returns scans' raw RSSI value as the level, per Android spec / APIs.
+             *   If your application depends on the previous behaviour, we have added an options object that will modify behaviour:
+             *   - if `(n == true || n < 2)`, `*.getScanResults({numLevels: n})` will return data as before, split in 5 levels;
+             *   - if `(n > 1)`, `*.getScanResults({numLevels: n})` will calculate the signal level, split in n levels;
+             *   - if `(n == false)`, `*.getScanResults({numLevels: n})` will use the raw signal level;
+             */
+
+            int level;
+
+            if (numLevels == null) {
+              level = scan.level;
+            } else {
+              level = wifiManager.calculateSignalLevel(scan.level, numLevels);
+            }
+
             JSONObject lvl = new JSONObject();
             try {
-                lvl.put("level", scan.level);
+                lvl.put("level", level);
                 lvl.put("SSID", scan.SSID);
                 lvl.put("BSSID", scan.BSSID);
                 returnList.put(lvl);

--- a/www/WifiWizard.js
+++ b/www/WifiWizard.js
@@ -190,16 +190,24 @@ var WifiWizard = {
 
 	/**
 	 *  Hands the list of scanned  networks to the `win` success callback function.
+   * @param   opts optional json object of options
 	 * @param 	win	callback function that receives list of networks
 	 * @param 	fail	callback function if error
 	 * @return		a list of networks
 	 */
-	getScanResults: function(win, fail) {
+	getScanResults: function(options, win, fail) {
+    if (typeof options === 'function') {
+      fail = win;
+      win = options;
+      options = {};
+    }
+
 		if (typeof win != "function") {
 			console.log("getScanResults first parameter must be a function to handle list.");
 			return;
 		}
-		cordova.exec(win, fail, 'WifiWizard', 'getScanResults', []);
+
+		cordova.exec(win, fail, 'WifiWizard', 'getScanResults', [options]);
 	},
 
 	/**


### PR DESCRIPTION
tested pretty extensively. try:

no options object—
```javascript```
WifiWizard.getScanResults(function(results} {
  console.log(results);
}, function() {
  console.log('fail :(');
});

// returns [{..., level: -54}, ...]
```

set false for raw signal level—
```javascript```
WifiWizard.getScanResults({numLevels: false}, function(results} {
  console.log(results);
}, function() {
  console.log('fail :(');
});

// returns [{..., level: -54}, ...]
```

set true for default calculated signal level (as before)—
```javascript```
WifiWizard.getScanResults({numLevels: true}, function(results} {
  console.log(results);
}, function() {
  console.log('fail :(');
});

// defaults to previous behaviour
// returns [{..., level: 2}, ...]
```

set an integer to calculate signal level with that numLevels—
```javascript```
WifiWizard.getScanResults({numLevels: 20}, function(results} {
  console.log(results);
}, function() {
  console.log('fail :(');
});

// runs calculateSignalLevel(level, numLevels)
// returns [{..., level: 19}, ...]
```