### PR TITLE
Fix null issues with getConnectedSSID

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -466,10 +466,10 @@ public class WifiWizard extends CordovaPlugin {
         }
 
         String ssid = info.getSSID();
-        if(ssid.isEmpty()) {
+        if(ssid == null || ssid.isEmpty()) {
             ssid = info.getBSSID();
         }
-        if(ssid.isEmpty()){
+        if(ssid == null || ssid.isEmpty() || ssid == "0x"){
             callbackContext.error("SSID is empty");
             return false;
         }


### PR DESCRIPTION
Fixes some of #52 (at least on my Nexus 5) and a null reference exception I was seeing on a Samsung Galaxy S5.
