### PR TITLE
Only return connected SSID if supplicantState i COMPLETED

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -478,6 +478,12 @@ public class WifiWizard extends CordovaPlugin {
             return false;
         }
 
+        SupplicantState state = info.getSupplicantState();
+        if(!state.equals(SupplicantState.COMPLETED)) {
+            callbackContext.error("Connection not in COMPLETED state");
+            return false;
+        }
+
         String ssid = info.getSSID();
         if(ssid.isEmpty()) {
             ssid = info.getBSSID();


### PR DESCRIPTION
Only return connected SSID if supplicantState i COMPLETED (Association and authentication is finished) and we are truly connected.

Currently wifi network SSID is returned as soon as network is associated (which means network doesn't have to be present at all).
