### PR TITLE
getConnectedSSID return value modified to remove unnecessary surround…

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -414,8 +414,13 @@ public class WifiWizard extends CordovaPlugin {
             callbackContext.error("SSID is empty");
             return false;
         }
+        
+        String surroundingQuotesRemovedIfAny = ssid.replaceAll("^\"|\"$", "");
+
+        ssid = surroundingQuotesRemovedIfAny;
 
         callbackContext.success(ssid);
+
         return true;
     }
 


### PR DESCRIPTION
getConnectedSSId yields SSID name with extra quotes on some versions of android (tested on 4.x). Now, it will remove the first surrounding pairs so that there's no need of parsing on the client side.

Examples:

- "SSID" --> SSID
- "SSID --> "SSID
- ""SSID"" --> "SSID"