### PR TITLE
yarn install was failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fork
 
 ```
-This fork solves issue with names in Ionic package.json. Especially convinient with automatic builds. 
+This fork solves issue with plugin naming in Ionic package.json. Especially convinient with automatic builds. 
 ```
 
 # WifiWizard

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Fork
+
+```
+This fork solves issue with names in Ionic package.json. Especially convinient with automatic builds. 
+```
+
 # WifiWizard
 
 Version 0.2.10

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.11",
   "description": "This plugin allows Phonegap applications to manage Wifi connections.",
   "cordova": {
-    "id": "com.pylonproducts.wifiwizard",
+    "id": "wifiwizard",
     "platforms": [
       "android",
       "ios"


### PR DESCRIPTION
due to naming issues, when installing `npm packages`, instal was failing.
This happend always when CI tried to build Ionic project from scratch