### PR TITLE
Fix memory leak on android

### DIFF
--- a/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
+++ b/src/android/src/com/pylonproducts/wifiwizard/WifiWizard.java
@@ -53,7 +53,7 @@ public class WifiWizard extends CordovaPlugin {
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
         super.initialize(cordova, webView);
-        this.wifiManager = (WifiManager) cordova.getActivity().getSystemService(Context.WIFI_SERVICE);
+        this.wifiManager = (WifiManager) cordova.getActivity().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
     }
 
     @Override


### PR DESCRIPTION
Gradle linter gives a warning:

    :lintVitalRelease/home/michael/Projects/smart-mirror/application/platforms/android/src/com/pylonproducts/wifiwizard/WifiWizard.java:57: Error: The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing cordova.getActivity() to cordova.getActivity().getApplicationContext() [WifiManagerLeak]
    this.wifiManager = (WifiManager) cordova.getActivity().getSystemService(Context.WIFI_SERVICE);


This PR resolves it.